### PR TITLE
Update KjennelseVaretekt message to 1.1

### DIFF
--- a/kontrakter/da/varetekt/KjennelseVaretekt.schema.json
+++ b/kontrakter/da/varetekt/KjennelseVaretekt.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://domstol.no/da/varetekt/1.0/KjennelseVaretekt.schema.json",
+  "$id": "https://domstol.no/da/varetekt/1.1/KjennelseVaretekt.schema.json",
   "description": "Schema definisjon av en Kjennelse-varetekt",
   "properties": {
     "forsendelse": {
@@ -29,7 +29,8 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/dokument"
-      }
+      },
+      "minItems": 1
     },
     "saksInformasjon": {
       "$ref": "#/definitions/saksInformasjon"
@@ -56,22 +57,18 @@
           "description": "Politiet sitt interne saksnummer"
         },
         "rettsmoeteTidFra": {
-          "$ref": "#/definitions/datoTid"
+          "$ref": "#/definitions/datoTid",
+          "description": "Dersom rettsmøte ikke avholdes, f.eks. ved kontorforrenting, skal dette feltet ikke fylles"
         },
         "rettsmoeteTidTil": {
-          "$ref": "#/definitions/datoTid"
+          "$ref": "#/definitions/datoTid",
+          "description": "Dersom rettsmøte ikke avholdes, f.eks. ved kontorforrenting, skal dette feltet ikke fylles"
         },
         "avgjoerelse": {
           "$ref": "#/definitions/avgjoerelse"
         }
       },
-      "required": [
-        "saksnummer",
-        "straffesaksnummer",
-        "rettsmoeteTidFra",
-        "rettsmoeteTidTil",
-        "avgjoerelse"
-      ],
+      "required": ["saksnummer", "straffesaksnummer", "avgjoerelse"],
       "type": "object",
       "additionalProperties": false
     },

--- a/kontrakter/da/varetekt/eksempelfiler/eksempel_kjennelseVaretektsfengsling_uten_rettsmoete.json
+++ b/kontrakter/da/varetekt/eksempelfiler/eksempel_kjennelseVaretektsfengsling_uten_rettsmoete.json
@@ -1,0 +1,111 @@
+{
+  "forsendelse": {
+    "meldingsId": "2CB6929E-DE3F-49A4-8AE3-9625640DF0AA",
+    "sendtTid": "2022-07-06T16:35:00+02:00",
+    "avsender": {
+      "organisasjon": {
+        "organisasjonsnummer": "826726342",
+        "navn": "Buskerud tingrett"
+      },
+      "person": {
+        "etternavn": "Saksbehandler",
+        "fornavn": "Litt",
+        "tittel": "Saksbehandler"
+      }
+    },
+    "mottaker": {
+      "organisasjon": {
+        "organisasjonsnummer": "983997953",
+        "navn": "Innlandet politidistrikt"
+      }
+    },
+    "rettelse": false
+  },
+  "aktoerer": {
+    "dommer": {
+      "etternavn": "Dommersen",
+      "fornavn": "Lars",
+      "tittel": "Dommerfullmeltig"
+    },
+    "saksbehandler": {
+      "etternavn": "Saksbehandler",
+      "fornavn": "Litt",
+      "tittel": "Saksbehandler"
+    }
+  },
+  "siktede": {
+    "identitetsnummer": {
+      "foedselsnummer": "14846399381"
+    },
+    "tilleggsId": [],
+    "fornavn": "Morsom",
+    "etternavn": "Kivi",
+    "kjoenn": "MANN",
+    "foedselsdato": "1963-04-14",
+    "nasjonalitet": {
+      "kode": "NOR",
+      "navn": "Norge"
+    }
+  },
+  "dokumenter": [
+    {
+      "internId": "9c3eced0-5792-4431-ae5c-ba0942c7e7bb",
+      "forsendelse": {
+        "mimeType": "application/pdf",
+        "sjekksum": "1a2eced0-5792-4431-ae5c-ba0942c7e7ac",
+        "uri": "9c3eced0-5792-4431-ae5c-ba0942c7e7bb"
+      },
+      "overskrift": "Rettsbok varetektsfengsling",
+      "skrevetDato": "2022-07-06",
+      "kategori": {
+        "kode": "DOKUMENTKATEGORI#RETTSBOK#1900-01-01",
+        "navn": "Rettsbok"
+      }
+    }
+  ],
+  "saksInformasjon": {
+    "saksnummer": "22-025462ENE-TBUS/TDRA",
+    "straffesaksnummer": "15434820",
+    "avgjoerelse": {
+      "avgjoerelseId": "A7972F79-0A35-4EC7-90A1-81E4EFAE1E31",
+      "avsagtDato": "2022-07-05",
+      "kravid": "16972F79-0A35-4EC7-90A1-81E4EFAE1E7E",
+      "restriksjoner": [
+        {
+          "restriksjonsId": "CCC72F79-0A35-4EC7-90A1-81E4EFAE1EEE",
+          "restriksjonsType": "BREV_OG_BESOEKSFORBUD",
+          "fraDato": "2022-07-06",
+          "tilDato": "2022-07-20"
+        },
+        {
+          "restriksjonsId": "DDD72F79-0A35-4EC7-90A1-81E4EFAE1FFF",
+          "restriksjonsType": "BREV_OG_BESOEKSKONTROLL",
+          "fraDato": "2022-07-21",
+          "tilDato": "2022-08-06"
+        }
+      ],
+      "isolasjonsKrav": [
+        {
+          "isolasjonsId": "EEE72F79-0A35-4EC7-90A1-81E4EFAE1777",
+          "isolasjonsType": "FULL",
+          "fraDato": "2022-07-06",
+          "tilDato": "2022-08-06"
+        }
+      ],
+      "fengsling": {
+        "fengslingsId": "FFF72F79-0A35-4EC7-90A1-81E4EFAE1888",
+        "fraDato": "2022-07-06",
+        "tilDato": "2022-08-06",
+        "fengslingsFristDato": "2022-07-06",
+        "lovbud": {
+          "lovbudStreng": "strpl § 184, jf. § 185, jf. § 171 nr. 2"
+        },
+        "merknad": "Kiwi må i varetekt så fort som fy"
+      },
+      "anke": {
+        "anketDato": "2022-07-06",
+        "oppsettendeVirkning": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
KjennelseVaretekt.schema.json: At least one document must be attached to the message. Removed required for "rettsmoeteTidFra" and "rettsmoeteTidTil". Added example file for "Kjennelse varetektsfengling uten rettsmøte"